### PR TITLE
Adding pickup, release and physics based collision sounds.

### DIFF
--- a/Packages/com.avr.core/Editor/DefaultPrefabs/PlayerRig.prefab
+++ b/Packages/com.avr.core/Editor/DefaultPrefabs/PlayerRig.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 3938096090804365495}
   - component: {fileID: 3938096090804365492}
   - component: {fileID: 3827808369406449854}
+  - component: {fileID: 4570842109220475869}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -100,11 +101,27 @@ MonoBehaviour:
   onDisable:
     m_PersistentCalls:
       m_Calls: []
+  destroyOnRemote: 1
+  changeLayerOnRemote: 0
+  changeLayerOnRemote_IncludeChildren: 0
+  remoteLayer: 0
+  onRemoteStart:
+    m_PersistentCalls:
+      m_Calls: []
   controllerNode: 2
   tracking: 1
   updateType: 2
   smoothing: 0
   smoothingFidelity: 0.3
+  synchronizeTransform: 0
+--- !u!81 &4570842109220475869
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3938096090804365491}
+  m_Enabled: 1
 --- !u!1 &3938096091124317167
 GameObject:
   m_ObjectHideFlags: 0
@@ -161,7 +178,15 @@ MonoBehaviour:
   onDisable:
     m_PersistentCalls:
       m_Calls: []
+  destroyOnRemote: 1
+  changeLayerOnRemote: 0
+  changeLayerOnRemote_IncludeChildren: 0
+  remoteLayer: 0
+  onRemoteStart:
+    m_PersistentCalls:
+      m_Calls: []
   MainCamera: {fileID: 3938096090804365492}
+  synchronizeRigPositions: 0
 --- !u!1 &3938096091130195902
 GameObject:
   m_ObjectHideFlags: 0

--- a/Packages/com.avr.phys/Runtime/ObjectTypes/GrabbableObjectType.cs
+++ b/Packages/com.avr.phys/Runtime/ObjectTypes/GrabbableObjectType.cs
@@ -3,6 +3,21 @@ using System.Collections.Generic;
 using UnityEngine;
 
 namespace AVR.Phys {
+
+    /// <summary>
+    /// Defines a set of sounds and modifiers to be played during physics events for GrabbableObjectType's
+    /// </summary>
+    [System.Serializable]
+    public struct GrabbableObjectSoundData
+    {
+        public AudioClip pickupSound;
+        public AudioClip releaseSound;
+        public AudioClip collideSound;
+
+        //Value from 0 - 1 that the AudioSource will use as a volume multiplier
+        [Range(0, 1)] public float volumeMultiplier;
+    }
+
     /// <summary>
     /// Defines how an object behaves whilst grabbed.
     /// </summary>
@@ -29,6 +44,8 @@ namespace AVR.Phys {
         // This multiplier will essentially make the target objects rigidbody weight = weight * 1.0/multiplier
         public float Heavy_force_multiplier = 1.0f;
 
+        public GrabbableObjectSoundData soundData;
+
         public static GrabbableObjectType defaultObjectType(){
             GrabbableObjectType o = new GrabbableObjectType();
             o.followType = FollowType.FREE;
@@ -38,7 +55,28 @@ namespace AVR.Phys {
             o.Lightness = 1.0f;
             o.Angular_Lightness = 1.0f;
             o.Break_grab_distance = 0.5f;
+            o.soundData.pickupSound = null;
+            o.soundData.releaseSound = null;
+            o.soundData.collideSound = null;
+            o.soundData.volumeMultiplier = 1.0f;
+            
             return o;
+        }
+
+        //When the user resets the scriptable object in the inspector, give them a default object.
+        private void Reset()
+        {
+            followType = FollowType.FREE;
+            handToObject = false;
+            allowTwoHanded = false;
+            changeObjectTypeOnTwoHanded = false;
+            Lightness = 1.0f;
+            Angular_Lightness = 1.0f;
+            Break_grab_distance = 0.5f;
+            soundData.pickupSound = null;
+            soundData.releaseSound = null;
+            soundData.collideSound = null;
+            soundData.volumeMultiplier = 1.0f;
         }
     }
 }

--- a/Packages/com.avr.phys/Runtime/Scripts/AVR_Grabbable.cs
+++ b/Packages/com.avr.phys/Runtime/Scripts/AVR_Grabbable.cs
@@ -28,6 +28,11 @@ namespace AVR.Phys {
         public Rigidbody rb;
 
         /// <summary>
+        /// Optional AudioSource to play sounds from GrabbableObjectType data
+        /// </summary>
+        public AudioSource source;
+
+        /// <summary>
         /// List of colliders that describe the outer/grabbable surface. All colliders must be convex.
         /// </summary>
         public List<Collider> colliders = new List<Collider>();
@@ -71,7 +76,17 @@ namespace AVR.Phys {
             if (rb == null) rb = GetComponent<Rigidbody>();
             if (colliders==null || colliders.Count<1) colliders.AddRange(GetComponentsInChildren<Collider>());
             if (nodes == null || nodes.Count < 1) nodes.AddRange(GetComponentsInChildren<AVR_GrabNode>());
-            if(objectType==null) objectType = GrabbableObjectType.defaultObjectType();
+            if (objectType == null) objectType = GrabbableObjectType.defaultObjectType();
+
+            //Throw warnings if audiosource isnt a 3D blending source
+            if (source != null)
+            {
+                if (source.spatialBlend == 0.0f)
+                {
+                    Debug.Log(this.name +
+                        "'s Audio Source has no spatial blend. 3D audio will not work. Consider setting spatial blend to 1");
+                }
+            }
         }
 
         void FixedUpdate()
@@ -107,6 +122,12 @@ namespace AVR.Phys {
             AttachedHands.Add(hand);
             hand.controller.HapticPulse(0.3f, 0.05f);
 
+            //Play pickup sound
+            if (source != null && objectType.soundData.pickupSound != null)
+            {
+                source.PlayOneShot(objectType.soundData.pickupSound, objectType.soundData.volumeMultiplier);
+            }
+
 #if AVR_NET
             if (IsOnline)
             {
@@ -126,6 +147,12 @@ namespace AVR.Phys {
                 transform.SetParent(old_parent);
                 if(velocities.Count>0) rb.velocity = new Vector3(velocities.Average(v => v.x), velocities.Average(v => v.y), velocities.Average(v => v.z));
                 velocities.Clear();
+
+                //Play release sound
+                if (source != null && objectType.soundData.releaseSound != null)
+                {
+                    source.PlayOneShot(objectType.soundData.releaseSound, objectType.soundData.volumeMultiplier);
+                }
             }
         }
 
@@ -280,6 +307,7 @@ namespace AVR.Phys {
                 return avg;
             }
         }
+
         void OnCollisionEnter(Collision collision)
         {
             // Haptic feedback
@@ -288,7 +316,35 @@ namespace AVR.Phys {
                 h.controller.HapticPulse(Mathf.Lerp(0, 0.5f, 0.2f * collision.relativeVelocity.magnitude), 0.05f);
             }
 
-            // TODO: Play sounds
+            //Play collision sound
+            if (source != null && objectType.soundData.collideSound != null && rb != null)
+            {
+                //Calculate a sound multiplier based off the velocity and mass of the collision
+                float soundMultiplier = objectType.soundData.volumeMultiplier;
+
+                float mass = rb.mass;
+                float speed = rb.velocity.magnitude;
+
+                //Equation adapted and modified from https://www.grc.nasa.gov/WWW/K-12/rocket/termvr.html
+                //This doesnt account for frontal area or drag.
+                //The 2.2 is the air density (1.1) multiplied by 2.
+                float terminalSpeed = Mathf.Sqrt(2.0f * mass * Physics.gravity.magnitude / 2.2f);
+
+                //When you grab an object, it teleports.
+                //This creates these wildly large speed values when grabbed. This will ignore them.
+                if (speed > terminalSpeed)
+                {
+                    return;
+                }
+
+                //Using the adapted terminal velocity, create a ratio from 0 - 1 of speed.
+                //Use this ratio as the sound multiplier. The faster the object moves, the louder the sound.
+                float physicsSoundMultiplier = speed / terminalSpeed;
+
+                soundMultiplier *= physicsSoundMultiplier;
+
+                source.PlayOneShot(objectType.soundData.collideSound, soundMultiplier);
+            }
         }
     }
 }

--- a/Packages/com.avr.phys/Runtime/Scripts/AVR_Grabbable.cs
+++ b/Packages/com.avr.phys/Runtime/Scripts/AVR_Grabbable.cs
@@ -77,6 +77,7 @@ namespace AVR.Phys {
             if (colliders==null || colliders.Count<1) colliders.AddRange(GetComponentsInChildren<Collider>());
             if (nodes == null || nodes.Count < 1) nodes.AddRange(GetComponentsInChildren<AVR_GrabNode>());
             if (objectType == null) objectType = GrabbableObjectType.defaultObjectType();
+            if (source == null) source = GetComponent<AudioSource>();
 
             //Throw warnings if audiosource isnt a 3D blending source
             if (source != null)
@@ -324,11 +325,13 @@ namespace AVR.Phys {
 
                 float mass = rb.mass;
                 float speed = rb.velocity.magnitude;
+                float drag = rb.drag == 0.0f ? 0.5f : rb.drag; //If the rigidbody drag is 0, use 0.5. Otherwise, use that drag.
+
+                const float frontalArea = 0.5f;
+                const float airDrag = 1.1f;
 
                 //Equation adapted and modified from https://www.grc.nasa.gov/WWW/K-12/rocket/termvr.html
-                //This doesnt account for frontal area or drag.
-                //The 2.2 is the air density (1.1) multiplied by 2.
-                float terminalSpeed = Mathf.Sqrt(2.0f * mass * Physics.gravity.magnitude / 2.2f);
+                float terminalSpeed = Mathf.Sqrt(2.0f * mass * Physics.gravity.magnitude / airDrag * frontalArea * drag);
 
                 //When you grab an object, it teleports.
                 //This creates these wildly large speed values when grabbed. This will ignore them.

--- a/Packages/com.avr.phys/Runtime/StockSounds.meta
+++ b/Packages/com.avr.phys/Runtime/StockSounds.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c3a5dca92a9347c4a9a98b1e6e848c2d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.avr.phys/Runtime/StockSounds/CollideSound.wav
+++ b/Packages/com.avr.phys/Runtime/StockSounds/CollideSound.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:38dba9b83eaea16b3c70bd3e46b9df682c9548a525bcb247f5a425ea8d1a2e12
+size 33126

--- a/Packages/com.avr.phys/Runtime/StockSounds/CollideSound.wav.meta
+++ b/Packages/com.avr.phys/Runtime/StockSounds/CollideSound.wav.meta
@@ -1,0 +1,22 @@
+fileFormatVersion: 2
+guid: 8aec3060caf20fe48a380270c14f442a
+AudioImporter:
+  externalObjects: {}
+  serializedVersion: 6
+  defaultSettings:
+    loadType: 0
+    sampleRateSetting: 0
+    sampleRateOverride: 44100
+    compressionFormat: 1
+    quality: 1
+    conversionMode: 0
+  platformSettingOverrides: {}
+  forceToMono: 0
+  normalize: 1
+  preloadAudioData: 1
+  loadInBackground: 0
+  ambisonic: 0
+  3D: 1
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.avr.phys/Runtime/StockSounds/PickupSound.wav
+++ b/Packages/com.avr.phys/Runtime/StockSounds/PickupSound.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ccab180886120ae4affa18d4552055d97c96e7eeec7f4422b69974f7a33cb348
+size 1032

--- a/Packages/com.avr.phys/Runtime/StockSounds/PickupSound.wav.meta
+++ b/Packages/com.avr.phys/Runtime/StockSounds/PickupSound.wav.meta
@@ -1,0 +1,22 @@
+fileFormatVersion: 2
+guid: ebd82e6eb233a5745a116680b2e1c524
+AudioImporter:
+  externalObjects: {}
+  serializedVersion: 6
+  defaultSettings:
+    loadType: 0
+    sampleRateSetting: 0
+    sampleRateOverride: 44100
+    compressionFormat: 1
+    quality: 1
+    conversionMode: 0
+  platformSettingOverrides: {}
+  forceToMono: 0
+  normalize: 1
+  preloadAudioData: 1
+  loadInBackground: 0
+  ambisonic: 0
+  3D: 1
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.avr.phys/Runtime/StockSounds/ReleaseSound.wav
+++ b/Packages/com.avr.phys/Runtime/StockSounds/ReleaseSound.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1564c6096612767d5a39baeb79459912a21339469e0d3e96c933375519f2ff08
+size 1032

--- a/Packages/com.avr.phys/Runtime/StockSounds/ReleaseSound.wav.meta
+++ b/Packages/com.avr.phys/Runtime/StockSounds/ReleaseSound.wav.meta
@@ -1,0 +1,22 @@
+fileFormatVersion: 2
+guid: 21feaeca1664dc64eaef3d3f41df90d2
+AudioImporter:
+  externalObjects: {}
+  serializedVersion: 6
+  defaultSettings:
+    loadType: 0
+    sampleRateSetting: 0
+    sampleRateOverride: 44100
+    compressionFormat: 1
+    quality: 1
+    conversionMode: 0
+  platformSettingOverrides: {}
+  forceToMono: 0
+  normalize: 1
+  preloadAudioData: 1
+  loadInBackground: 0
+  ambisonic: 0
+  3D: 1
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This PR adds code and sounds for pickup, release and collisions audio. Resolves issue #3 

The sounds can be configured per `GrabbableObjectType` as seen below.

![](https://i.imgur.com/4JKqZzJ.png)

Pickup and release sounds sounds are played when an `AVR_Grabbable` grabs/releases an object.

Collision sounds will be played whenever a collision happens, and the volume will be multiplied based on the speed and mass of the object being collided, providing more realistic collision sounds.

Each sound is optional, and the system will work fine if any of them are left null. 

This PR also adds an `AudioListener` component to the main camera on the PlayerRig prefab.

## Please Note
I am not super familiar with the codebase, and I may have broke formatting rules that you used to write it. I couldnt find a file with contributing information, so if I made any mistakes with your projects formatting standard please do let me know and I will fix them!