### PR TITLE
Added support for multiple drop sounds to play randomly

### DIFF
--- a/Packages/com.avr.phys/Runtime/ObjectTypes/GrabbableObjectType.cs
+++ b/Packages/com.avr.phys/Runtime/ObjectTypes/GrabbableObjectType.cs
@@ -12,7 +12,7 @@ namespace AVR.Phys {
     {
         public AudioClip pickupSound;
         public AudioClip releaseSound;
-        public AudioClip collideSound;
+        public List<AudioClip> collideSounds;
 
         //Value from 0 - 1 that the AudioSource will use as a volume multiplier
         [Range(0, 1)] public float volumeMultiplier;
@@ -57,7 +57,7 @@ namespace AVR.Phys {
             o.Break_grab_distance = 0.5f;
             o.soundData.pickupSound = null;
             o.soundData.releaseSound = null;
-            o.soundData.collideSound = null;
+            o.soundData.collideSounds = new List<AudioClip>();
             o.soundData.volumeMultiplier = 1.0f;
             
             return o;
@@ -75,7 +75,7 @@ namespace AVR.Phys {
             Break_grab_distance = 0.5f;
             soundData.pickupSound = null;
             soundData.releaseSound = null;
-            soundData.collideSound = null;
+            soundData.collideSounds = new List<AudioClip>();
             soundData.volumeMultiplier = 1.0f;
         }
     }

--- a/Packages/com.avr.phys/Runtime/Scripts/AVR_Grabbable.cs
+++ b/Packages/com.avr.phys/Runtime/Scripts/AVR_Grabbable.cs
@@ -318,7 +318,7 @@ namespace AVR.Phys {
             }
 
             //Play collision sound
-            if (source != null && objectType.soundData.collideSound != null && rb != null)
+            if (source != null && objectType.soundData.collideSounds != null && objectType.soundData.collideSounds.Count != 0 && rb != null)
             {
                 //Calculate a sound multiplier based off the velocity and mass of the collision
                 float soundMultiplier = objectType.soundData.volumeMultiplier;
@@ -346,7 +346,8 @@ namespace AVR.Phys {
 
                 soundMultiplier *= physicsSoundMultiplier;
 
-                source.PlayOneShot(objectType.soundData.collideSound, soundMultiplier);
+                AudioClip randomClip = objectType.soundData.collideSounds[Random.Range(0, objectType.soundData.collideSounds.Count)];
+                source.PlayOneShot(randomClip, soundMultiplier);
             }
         }
     }

--- a/Packages/com.avr.phys/Runtime/Scripts/AVR_Grabbable.cs
+++ b/Packages/com.avr.phys/Runtime/Scripts/AVR_Grabbable.cs
@@ -77,6 +77,7 @@ namespace AVR.Phys {
             if (colliders==null || colliders.Count<1) colliders.AddRange(GetComponentsInChildren<Collider>());
             if (nodes == null || nodes.Count < 1) nodes.AddRange(GetComponentsInChildren<AVR_GrabNode>());
             if (objectType == null) objectType = GrabbableObjectType.defaultObjectType();
+            if (source == null) source = GetComponent<AudioSource>();
 
             //Throw warnings if audiosource isnt a 3D blending source
             if (source != null)
@@ -324,11 +325,13 @@ namespace AVR.Phys {
 
                 float mass = rb.mass;
                 float speed = rb.velocity.magnitude;
+                float drag = rb.drag == 0.0f ? 0.5f : rb.drag; //If the rigidbody drag is 0, use 0.5. Otherwise, use that drag.
+
+                const float frontalArea = 0.5f;
+                const float airDrag = 1.1f;
 
                 //Equation adapted and modified from https://www.grc.nasa.gov/WWW/K-12/rocket/termvr.html
-                //This doesnt account for frontal area or drag.
-                //The 2.2 is the air density (1.1) multiplied by 2.
-                float terminalSpeed = Mathf.Sqrt(2.0f * mass * Physics.gravity.magnitude / 2.2f);
+                float terminalSpeed = Mathf.Sqrt(2.0f * mass * Physics.gravity.magnitude / airDrag * frontalArea * drag);
 
                 //When you grab an object, it teleports.
                 //This creates these wildly large speed values when grabbed. This will ignore them.


### PR DESCRIPTION
Hello!

Something I noticed while using the project is that the drop sound can become quite repetitive, so this PR adds support for multiple different drop sounds per `GrabbableObjectType`, and randomly plays them on collision.

Instead of a single `AudioClip` object, the system now uses a `List<AudioClip>` for the collision sounds, and randomly picks from them.

## Something of Note:

Anyone who updates to this change may have their current AudioClip's for collisions break. This is because this code changes the collideSounds type in GrabbableObjectType, which will clear whatever they have assigned to it in the inspector when Unity serializes it. They will have to redrag their AudioClip's into the inspector.